### PR TITLE
Ignore non-existant cgroups

### DIFF
--- a/pkg/cgroups/cgroup.go
+++ b/pkg/cgroups/cgroup.go
@@ -17,6 +17,7 @@ const (
 
 var (
 	ErrUndefinedController error = errors.New("undefined controller type")
+	ErrDoesNotExist        error = errors.New("cgroup does not exist")
 )
 
 //ControlType supported cgroup controller types

--- a/pkg/cgroups/cpu.go
+++ b/pkg/cgroups/cpu.go
@@ -39,7 +39,7 @@ func (ca *CPUAcct) Stats() (uint64, error) {
 func (ca *CPUAcct) statsV1() (uint64, error) {
 	res, err := readFileAsUint64(filepath.Join(ca.path, "cpuacct.usage"))
 	if err != nil {
-		return 0, errors.Wrapf(err, "retrieving cpu stats cgroup v1")
+		return 0, ErrDoesNotExist
 	}
 	return res, nil
 }
@@ -49,7 +49,7 @@ func (ca *CPUAcct) statsV2() (uint64, error) {
 
 	values, err := readCgroup2MapPath(p)
 	if err != nil {
-		return 0, errors.Wrapf(err, "retrieving cpu stats cgroup v2")
+		return 0, ErrDoesNotExist
 	}
 
 	var total uint64

--- a/pkg/cgroups/memory.go
+++ b/pkg/cgroups/memory.go
@@ -40,7 +40,7 @@ func (m *Memory) Stats() (uint64, error) {
 func (m *Memory) statsV1() (uint64, error) {
 	res, err := readFileAsUint64(filepath.Join(m.path, "memory.usage_in_bytes"))
 	if err != nil {
-		return 0, errors.Wrapf(err, "retrieving memory stats cgroup v1")
+		return 0, ErrDoesNotExist
 	}
 	return res, nil
 }
@@ -50,7 +50,7 @@ func (m *Memory) statsV2() (uint64, error) {
 
 	stat, err := ioutil.ReadFile(p)
 	if err != nil {
-		return 0, err
+		return 0, ErrDoesNotExist
 	}
 
 	ret, err := strconv.Atoi(strings.TrimSpace(string(stat)))

--- a/pkg/virt/virt.go
+++ b/pkg/virt/virt.go
@@ -57,11 +57,13 @@ func ContainersStats(cgroupControls ...cgroups.ControlType) (MetricMatrix, error
 			}
 
 			stat, err := cgCtrl.Stats()
-			if err != nil {
+			if err != nil && err != cgroups.ErrDoesNotExist {
 				return nil, err
 			}
 
-			retMatrix[cLabel][control] = stat
+			if err != cgroups.ErrDoesNotExist {
+				retMatrix[cLabel][control] = stat
+			}
 		}
 	}
 	return retMatrix, nil


### PR DESCRIPTION
Do not write stats from non-running containers to collectd writer